### PR TITLE
PyPI doesn't have Apple M1 version

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -20,7 +20,9 @@ jobs:
         - os: macos-13
           python-version: '3.7'
         - os: macos-14
-          python-version: '3.10'
+          python-version: '3.7'
+        - os: macos-14
+          python-version: '3.8'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -19,6 +19,8 @@ jobs:
           python-version: '3.12'
         - os: macos-13
           python-version: '3.7'
+        - os: macos-14
+          python-version: '3.10'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -43,10 +43,6 @@ jobs:
       run: |
         sudo apt-get update -qq -y
         sudo apt-get install -qq -y libglu1-mesa build-essential libeigen3-dev
-    - name: Install Brew On Mac OS
-      if: matrix.os == 'macos-14' || matrix.os == 'macos-13'
-      run: |
-        brew install eigen
     - name: Install dependencies
       run: |
         python3 -m pip install --upgrade pip
@@ -55,7 +51,7 @@ jobs:
 
     - name: Build
       run: |
-        python3 setup.py bdist_wheel
+        pip wheel . --no-deps --wheel-dir dist
 
     - name: Publish (Windows)
       env:

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9, '3.10', '3.11', '3.12']
-        os: [ubuntu-latest, macos-latest, macos-13, windows-latest]
+        os: [ubuntu-latest, macos-13, macos-14, windows-latest]
         exclude:
         - os: ubuntu-latest
           python-version: '3.12'
@@ -40,7 +40,7 @@ jobs:
         sudo apt-get update -qq -y
         sudo apt-get install -qq -y libglu1-mesa build-essential libeigen3-dev
     - name: Install Brew On Mac OS
-      if: matrix.os == 'macos-latest' || matrix.os == 'macos-13'
+      if: matrix.os == 'macos-14' || matrix.os == 'macos-13'
       run: |
         brew install eigen
     - name: Install dependencies
@@ -65,7 +65,7 @@ jobs:
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      if: matrix.os == 'macos-latest'
+      if: matrix.os == 'macos-13' || matrix.os == 'macos-14'
       run: |
         python3 -m twine upload dist/*
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,12 @@ else(WIN32)
     #target_link_libraries(Clipper2 PUBLIC -lm)
 
     # Find Required packages
-    find_package(Eigen3 3.3 REQUIRED)
+    find_package(Eigen3 3.3)
+    if (NOT EIGEN3_FOUND)
+        message(WARNING "Eigen3 not found, will build with the included version.")
+        set(EIGEN3_INCLUDE_DIR external/eigen)
+    endif(NOT EIGEN3_FOUND)
+
 
 endif(WIN32)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "cmake"]


### PR DESCRIPTION
Some changes to build locally just using "pip" on an M1 mac, and then maybe also help with the github action, but I don't know if it will work.  At least this branch can by build directly by pip or poetry for use in other projects.